### PR TITLE
Fix issuing certificates for subdomains

### DIFF
--- a/certbot_dns_freenom/dns_freenom.py
+++ b/certbot_dns_freenom/dns_freenom.py
@@ -75,7 +75,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         )
 
 
-class _FreenomDNSClient:
+class _FreenomDNSClient():
     """
     Encapsulates all communication with the Freenom API.
     """
@@ -84,9 +84,18 @@ class _FreenomDNSClient:
         self.freenom = Freenom(username, password)
 
     def add_txt_record(self, domain, record_name, record_content, record_ttl):
-        """Add txt record"""
-        self.freenom.setRecord(domain, record_name, "TXT", record_content, record_ttl)
+        """ Add txt record """
+        if domain.count('.') > 1:
+            print ("Subdomain is used")
+            domain_list=domain.split('.')
+            domain = ".".join(domain_list[-2:])
+        print ("Add record: ",domain, record_name,record_content)
+        self.freenom.setRecord(domain, record_name, 'TXT', record_content, record_ttl)
 
     def del_txt_record(self, domain, record_name, record_content, record_ttl):
-        """Delete txt record"""
-        self.freenom.delRecord(domain, record_name, "TXT", record_content, record_ttl)
+        """ Delete txt record """
+        if domain.count('.') > 1:
+            domain_list=domain.split('.')
+            domain = ".".join(domain_list[-2:])
+        print ("Delete record: ",domain, record_name,record_content)
+        self.freenom.delRecord(domain, record_name, 'TXT', record_content, record_ttl)


### PR DESCRIPTION
https://github.com/Shm013/certbot-dns-freenom/issues/9

This's not so beautiful code for usage subdomain:
Output:

certbot -v certonly --agree-tos -a dns-freenom --dns-freenom-credentials ./credentials.ini --dns-freenom-propagation-seconds 30 -d "name.example.ml"
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator dns-freenom, Installer None
Requesting a certificate for name.example.ml
Performing the following challenges:
dns-01 challenge for name.example.com
Subdomain is used
Add record:  example.ml _acme-challenge.name.example.ml Eh5twPV2a-SOME_HASH_HERE-AZkf-Iag3jxuSA
setRecord: Record added successfully