### PR TITLE
Remove zope stuff

### DIFF
--- a/certbot_dns_freenom/dns_freenom.py
+++ b/certbot_dns_freenom/dns_freenom.py
@@ -16,14 +16,11 @@
 import zope.interface
 from freenom import Freenom
 
-from certbot import interfaces
 from certbot.plugins import dns_common
 
 ACCOUNT_KEYS_URL = "https://my.Freenom.ru/profile/apikeys"
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Freenom DNS
 


### PR DESCRIPTION
See https://github.com/certbot/certbot/pull/8950 and https://github.com/certbot/certbot/pull/9161: the `zope` dependency and `IAuthenticator` and `IPluginFactory` classes have been removed from Certbot. Currently, this plugin doesn't work with Certbot 2.0.0: it errors out with the "AttributeError: module 'certbot.interfaces' has no attribute 'IAuthenticator'" error.